### PR TITLE
Add docker-compose setup for development

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV -b 0.0.0.0
+worker: bundle exec sidekiq -c 5 -v
+webpacker: bin/webpack-dev-server

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -p $PORT -e $RAILS_ENV -b 0.0.0.0
+web: bin/rails server -p $PORT -b 0.0.0.0
 worker: bundle exec sidekiq -c 5 -v
 webpacker: bin/webpack-dev-server

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ This Ruby on Rails / React app collects competition entries for the Cookpad Mame
 - rake db:setup
   - This should run migrate and seed
 
+#### Docker setup
+There is also a docker-compose configuration which will start a postgres, redis and frontend container and starts all services.
+However, there are some parts which still need manual configuration
+
+* Set your local user id in the ``docker-compose.override.yml`` file. This is needed because we mount the sources into the container
+and the user in the container can have a different user id which would cause permission problems if you change the files while
+running the container. In most linux system you can get the user id with ``echo $UID``, replace ``CONTAINER_USERID`` in ``docker-compose.override.yml``
+with this number.
+
+* When starting the first time the containers, it is necessary to build the frontend container with ``docker-compose build``
+
+* To setup the database, start the containers with ``docker-compose up``, enter frontend container with ``docker-compose exec frontend /bin/bash``
+and execute ``rails db:setup``.
+
+* To start the rails application, run ``docker-compose up``
+
 ### Basic auth
 
 This application has basic authentication. The default username is `admin` and the default password is `password`.

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV["DATABASE_URL"] %>
 
 development:
   <<: *default
@@ -82,4 +83,3 @@ production:
   <<: *default
   database: mame-challenge_production
   username: mame-challenge
-  password: <%= ENV['MAME-CHALLENGE_DATABASE_PASSWORD'] %>

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '2.1'
+services:
+  frontend:
+    build:
+      args:
+        CONTAINER_USERID: 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "2.1"
+services:
+  db:
+    image: postgres:latest
+    environment:
+      - POSTGRES_PASSWORD=12345
+      - POSTGRES_USER=www-data
+    ports:
+      - "5432:5432"
+  cache:
+    image: redis
+    ports:
+      - "6379:6379"
+  frontend:
+    command: bash -c "rm -rf tmp/pids/server.pid && foreman start -f Procfile.dev"
+    build:
+      dockerfile: docker-files/Dockerfile
+      context: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/var/www/mame-challenge
+    environment:
+      - RAILS_ENV=development
+      - REDIS_URL=redis://cache:6379/5
+      - DATABASE_URL=postgresql://www-data:12345@db/mame-challenge_development
+      - PORT=3000
+    depends_on:
+      - db
+      - cache
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     volumes:
       - .:/var/www/mame-challenge
     environment:
-      - RAILS_ENV=development
       - REDIS_URL=redis://cache:6379/5
       - DATABASE_URL=postgresql://www-data:12345@db/mame-challenge_development
       - PORT=3000

--- a/docker-files/Dockerfile
+++ b/docker-files/Dockerfile
@@ -1,0 +1,36 @@
+FROM ruby:2.4.4
+
+ARG CONTAINER_USERID
+
+# Configure our user
+RUN usermod -u $CONTAINER_USERID www-data
+
+# Install dependencies
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install yarn nodejs
+
+# We copy the Gemfiles into this intermediate build stage so it's checksum
+# changes and all the subsequent stages (a.k.a. the bundle install call below)
+# have to be rebuild. Otherwise, after the first build of this image,
+# docker would use it's cache for this and the following stages.
+ADD Gemfile /var/www/mame-challenge/Gemfile
+ADD Gemfile.lock /var/www/mame-challenge/Gemfile.lock
+ADD package.json /var/www/mame-challenge/package.json
+ADD yarn.lock /var/www/mame-challenge/yarn.lock
+RUN chown -R www-data /var/www/
+
+# Now do the rest as the user with the same ID as the user who
+# builds this container
+USER www-data
+WORKDIR /var/www/mame-challenge
+
+# Install foreman
+RUN gem install foreman
+# Refresh our bundle
+RUN export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 || bundle install --jobs=3 --retry=3
+RUN yarn install
+
+# Run our command
+CMD ["foreman", "start", "-f", "Procfile.dev"]


### PR DESCRIPTION
To make it easier to setup the whole development environment and avoid
to run a postgres / redis instance on your local development machine.

The docker-compose file will start three containers:
* postgres database (db)
* redis (cache)
* frontend (sidekiq, puma & webpacker)

We use the official postgres, redis and ruby docker images from DockerHub.

When starting the first time the containers, it is necessary to build the
frontend container with docker-compose build. After that, the containers
can get started with docker-compose up.

See updated README file for a more detailed explanation how to use
the docker setup.

Just as a suggestion as I prefer to run my development environments in isolation and keep my Laptop 'clean'. Feel free to close it if you don't like it.

It would be possible to automate the manual steps from README even further with a e.g. Rake task but this can be done in a separate PR.

Also I'm not sure about my changes to the ``Procfile`` if you use this in 'production' then these change are probably not possible.